### PR TITLE
Fix folder typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ Thanks to Astro Navigation, adding new pages is as simple as adding a file to sr
 Starting from the top, you can see some data enclosed in --- tags. This is known as the page's front matter, which provides additional data to when it comes to
 rendering your pages.
 
-To add sub-pages, you will first need to create a new folder under `src/pages/` and populate it with `.astro` pages. Look at the `src/pages/projects` forlder for an example. Don't forget to edit `navData.json` to handle the navigation. The navigation bar is already set up to create drop-down menus.
+To add sub-pages, you will first need to create a new folder under `src/pages/` and populate it with `.astro` pages. Look at the `src/pages/projects` folder for an example. Don't forget to edit `navData.json` to handle the navigation. The navigation bar is already set up to create drop-down menus.
 
 <a name="navigationViaFrontMatter"></a>
 


### PR DESCRIPTION
## Summary
- fix a small typo in README

## Testing
- `node -e "console.log('no tests')"`