### PR TITLE
Fix CSPicture media attribute syntax

### DIFF
--- a/src/components/TemplateComponents/CSPicture.astro
+++ b/src/components/TemplateComponents/CSPicture.astro
@@ -40,8 +40,8 @@ const fallbackImg = await getImage({
 
 <!-- Adjust the width and height attributes sizes based on the stitch you're using -->
 <picture>
-    <source media=`(max-width: ${mobileMediaWidth})` srcset={mobileImg.src} />
-    <source media=`(min-width: ${desktopMediaWidth})` srcset={desktopImg.src} />
+    <source media={`(max-width: ${mobileMediaWidth})`} srcset={mobileImg.src} />
+    <source media={`(min-width: ${desktopMediaWidth})`} srcset={desktopImg.src} />
     <img
       aria-hidden="true"
       decoding="async"


### PR DESCRIPTION
## Summary
- fix invalid `media` attribute syntax in `CSPicture.astro`

## Testing
- `npm run build` *(fails: `astro` not found)*