### PR TITLE
Add basic utils tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
 		"dev": "astro dev",
 		"start": "astro dev",
 		"build": "astro build",
-		"preview": "astro preview"
-	},
+               "preview": "astro preview",
+               "test": "vitest"
+       },
 	"dependencies": {
 		"@astrojs/check": "^0.9.4",
 		"@astrojs/sitemap": "^3.4.0",
@@ -16,6 +17,9 @@
 		"astro-icon": "^1.1.5",
 		"autoprefixer": "^10.4.20",
 		"less": "^4.2.0",
-		"typescript": "^5.6.3"
-	}
+               "typescript": "^5.6.3"
+       },
+       "devDependencies": {
+               "vitest": "^1.0.0"
+       }
 }

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { formatDate, getCurrentYear } from '../src/js/utils.js';
+
+describe('utils', () => {
+  it('formats date to "MMM D, YYYY"', () => {
+    expect(formatDate('2020-01-02')).toBe('Jan 2, 2020');
+  });
+
+  it('returns the current year', () => {
+    const year = new Date().getFullYear();
+    expect(getCurrentYear()).toBe(year);
+  });
+});


### PR DESCRIPTION
## Summary
- add `vitest` as dev dependency and npm test script
- add initial `utils.test.js` for `formatDate` and `getCurrentYear`

## Testing
- `npm test` *(fails: `vitest` not found)*