### PR TITLE
Add basic utils tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
 		"dev": "astro dev",
 		"start": "astro dev",
 		"build": "astro build",
-		"preview": "astro preview"
-	},
+               "preview": "astro preview",
+               "test": "node --test"
+       },
 	"dependencies": {
 		"@astrojs/check": "^0.9.4",
 		"@astrojs/sitemap": "^3.4.0",
@@ -16,6 +17,7 @@
 		"astro-icon": "^1.1.5",
 		"autoprefixer": "^10.4.20",
 		"less": "^4.2.0",
-		"typescript": "^5.6.3"
-	}
+               "typescript": "^5.6.3"
+       },
+       "devDependencies": {}
 }

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,0 +1,12 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { formatDate, getCurrentYear } from '../src/js/utils.js';
+
+test('formats date to "MMM D, YYYY"', () => {
+  assert.equal(formatDate('2020-01-02'), 'Jan 2, 2020');
+});
+
+test('returns the current year', () => {
+  const year = new Date().getFullYear();
+  assert.equal(getCurrentYear(), year);
+});


### PR DESCRIPTION
## Summary
- switch test runner to `node:test`
- implement tests for `formatDate` and `getCurrentYear`

## Testing
- `npm test`
