### PR TITLE
Fix test script pattern and assertions

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"start": "astro dev",
 		"build": "astro build",
                "preview": "astro preview",
-               "test": "node --test"
+               "test": "node --test \"tests/**/*.test.js\""
        },
 	"dependencies": {
 		"@astrojs/check": "^0.9.4",

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -3,10 +3,10 @@ import assert from 'node:assert/strict';
 import { formatDate, getCurrentYear } from '../src/js/utils.js';
 
 test('formats date to "MMM D, YYYY"', () => {
-  assert.equal(formatDate('2020-01-02'), 'Jan 2, 2020');
+  assert.strictEqual(formatDate('2020-01-02'), 'Jan 2, 2020');
 });
 
 test('returns the current year', () => {
   const year = new Date().getFullYear();
-  assert.equal(getCurrentYear(), year);
+  assert.strictEqual(getCurrentYear(), year);
 });


### PR DESCRIPTION
## Summary
- run Node test runner against explicit test files
- use strict assertions in utils tests

## Testing
- `npm test`